### PR TITLE
compromise of Sass 3.3, 3.4.11 and libsass

### DIFF
--- a/_trumps.spacing-responsive.scss
+++ b/_trumps.spacing-responsive.scss
@@ -46,21 +46,18 @@ $inuit-generate-spacing-alias: null;
     // Loop through our previously-defined breakpoints.
     @each $breakpoint in $breakpoints {
 
-        $inuit-generate-spacing-alias:      nth($breakpoint, 1);
+        $inuit-generate-spacing-alias:      nth($breakpoint, 1) !global;
         $inuit-generate-spacing-condition:  nth($breakpoint, 2);
 
         // This isn’t ideal, but we definitely don’t want to generate widths
         // for retina devices. Exclude retina media-qeuries manually.
         @if ($inuit-generate-spacing-alias != "retina") {
-    
+
             @include media-query($inuit-generate-spacing-alias) {
                 @content;
             } // Close media query.
 
         } // Close retina check.
-
-        // Reset the global spacing alias back to null; 
-        $inuit-generate-spacing-alias: null;
 
     } // Close breakpoints loop.
 


### PR DESCRIPTION
Unfortunately, this will not work properly in Sass 3.4.11.
Maybe we can exclude Sass 3.2, because it was never running anyway, and optimise it for 3.3+ and libsass.
